### PR TITLE
VSCode snippet for creating a Command

### DIFF
--- a/.vscode/xbot-snippets.code-snippets
+++ b/.vscode/xbot-snippets.code-snippets
@@ -1,0 +1,44 @@
+{
+	// Place your TeamXbot2019 workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+	"XCommand" : {
+		"scope": "java",
+		"prefix": "xcommand",
+		"body": [
+			"package ${TM_DIRECTORY/.*java\\/([^\\/]*)\\/([^\\/]*)\\/([^\\/]*)\\/([^\\/]*).*/$1.$2.$3.$4/};",
+			"",
+			"import com.google.inject.Inject;",
+			"import xbot.common.command.BaseCommand;",
+			"",
+			"public class ${1:$TM_FILENAME_BASE} extends BaseCommand {",
+			"",
+			"\t@Inject",
+			"\tpublic $1() {",
+			"\t}",
+			"",
+			"\t@Override",
+    		"\tpublic void initialize() {",
+        	"\t\tlog.info(\"Initializing\");",
+    		"\t}",
+			"",
+    		"\t@Override",
+			"\tpublic void execute() {",
+			"\t}",
+			"}"
+		]
+	}
+}


### PR DESCRIPTION
Proof of concept. Typing `xcommand` in a new file will populate the following based on the filename and path:

![image](https://user-images.githubusercontent.com/399279/64481227-ad9ec180-d18c-11e9-9ae6-3d712b791bb9.png)

the package stuff is pretty brittle, but might handle the common cases. Also this should probably eventually be in the Template project instead.
